### PR TITLE
Change route for help page

### DIFF
--- a/src/components/help.jsx
+++ b/src/components/help.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import NavBar from './../components/nav_bar.jsx';
 
-const Info = () => (
+const Help = () => (
   <div>
     <NavBar />
     <h1>How to use the app?</h1>
@@ -13,4 +13,4 @@ const Info = () => (
   </div>
 );
 
-export default Info;
+export default Help;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -4,7 +4,7 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import Career from './containers/career.jsx';
 import CareerDetails from './containers/career_details.jsx';
 import List from './containers/list.jsx';
-import Info from './containers/info.jsx';
+import Help from './components/help.jsx';
 
 const Routes = () => (
   <BrowserRouter>
@@ -12,7 +12,7 @@ const Routes = () => (
       <Route path='/career' exact component={Career} />
       <Route path='/career/:title' exact component={CareerDetails} />
       <Route path='/list' exact component={List} />
-      <Route path='/info' exact component={Info} />
+      <Route path='/help' exact component={Help} />
     </Switch>
   </BrowserRouter>
 );


### PR DESCRIPTION
Relates #41

Change the route after changing the name and path of the file from `info` to `help` (we already have `career_info` so it seems confusing)
